### PR TITLE
Add integrity checks to container

### DIFF
--- a/rzp/src/crypto_utils.h
+++ b/rzp/src/crypto_utils.h
@@ -1,0 +1,155 @@
+#ifndef RZP_CRYPTO_UTILS_H
+#define RZP_CRYPTO_UTILS_H
+
+#include <cstdint>
+#include <vector>
+#include <array>
+#include <stdexcept>
+
+namespace rzp {
+
+inline uint32_t crc32(const std::vector<uint8_t>& data) {
+    static constexpr uint32_t table[256] = {
+        0x00000000U, 0x77073096U, 0xEE0E612CU, 0x990951BAU, 0x076DC419U, 0x706AF48FU, 0xE963A535U, 0x9E6495A3U,
+        0x0EDB8832U, 0x79DCB8A4U, 0xE0D5E91EU, 0x97D2D988U, 0x09B64C2BU, 0x7EB17CBDU, 0xE7B82D07U, 0x90BF1D91U,
+        0x1DB71064U, 0x6AB020F2U, 0xF3B97148U, 0x84BE41DEU, 0x1ADAD47DU, 0x6DDDE4EBU, 0xF4D4B551U, 0x83D385C7U,
+        0x136C9856U, 0x646BA8C0U, 0xFD62F97AU, 0x8A65C9ECU, 0x14015C4FU, 0x63066CD9U, 0xFA0F3D63U, 0x8D080DF5U,
+        0x3B6E20C8U, 0x4C69105EU, 0xD56041E4U, 0xA2677172U, 0x3C03E4D1U, 0x4B04D447U, 0xD20D85FDU, 0xA50AB56BU,
+        0x35B5A8FAU, 0x42B2986CU, 0xDBBBC9D6U, 0xACBCF940U, 0x32D86CE3U, 0x45DF5C75U, 0xDCD60DCFU, 0xABD13D59U,
+        0x26D930ACU, 0x51DE003AU, 0xC8D75180U, 0xBFD06116U, 0x21B4F4B5U, 0x56B3C423U, 0xCFBA9599U, 0xB8BDA50FU,
+        0x2802B89EU, 0x5F058808U, 0xC60CD9B2U, 0xB10BE924U, 0x2F6F7C87U, 0x58684C11U, 0xC1611DABU, 0xB6662D3DU,
+        0x76DC4190U, 0x01DB7106U, 0x98D220BCU, 0xEFD5102AU, 0x71B18589U, 0x06B6B51FU, 0x9FBFE4A5U, 0xE8B8D433U,
+        0x7807C9A2U, 0x0F00F934U, 0x9609A88EU, 0xE10E9818U, 0x7F6A0DBBU, 0x086D3D2DU, 0x91646C97U, 0xE6635C01U,
+        0x6B6B51F4U, 0x1C6C6162U, 0x856530D8U, 0xF262004EU, 0x6C0695EDU, 0x1B01A57BU, 0x8208F4C1U, 0xF50FC457U,
+        0x65B0D9C6U, 0x12B7E950U, 0x8BBEB8EAU, 0xFCB9887CU, 0x62DD1DDFU, 0x15DA2D49U, 0x8CD37CF3U, 0xFBD44C65U,
+        0x4DB26158U, 0x3AB551CEU, 0xA3BC0074U, 0xD4BB30E2U, 0x4ADFA541U, 0x3DD895D7U, 0xA4D1C46DU, 0xD3D6F4FBU,
+        0x4369E96AU, 0x346ED9FCU, 0xAD678846U, 0xDA60B8D0U, 0x44042D73U, 0x33031DE5U, 0xAA0A4C5FU, 0xDD0D7CC9U,
+        0x5005713CU, 0x270241AAU, 0xBE0B1010U, 0xC90C2086U, 0x5768B525U, 0x206F85B3U, 0xB966D409U, 0xCE61E49FU,
+        0x5EDEF90EU, 0x29D9C998U, 0xB0D09822U, 0xC7D7A8B4U, 0x59B33D17U, 0x2EB40D81U, 0xB7BD5C3BU, 0xC0BA6CADU,
+        0xEDB88320U, 0x9ABFB3B6U, 0x03B6E20CU, 0x74B1D29AU, 0xEAD54739U, 0x9DD277AFU, 0x04DB2615U, 0x73DC1683U,
+        0xE3630B12U, 0x94643B84U, 0x0D6D6A3EU, 0x7A6A5AA8U, 0xE40ECF0BU, 0x9309FF9DU, 0x0A00AE27U, 0x7D079EB1U,
+        0xF00F9344U, 0x8708A3D2U, 0x1E01F268U, 0x6906C2FEU, 0xF762575DU, 0x806567CBU, 0x196C3671U, 0x6E6B06E7U,
+        0xFED41B76U, 0x89D32BE0U, 0x10DA7A5AU, 0x67DD4ACCU, 0xF9B9DF6FU, 0x8EBEEFF9U, 0x17B7BE43U, 0x60B08ED5U,
+        0xD6D6A3E8U, 0xA1D1937EU, 0x38D8C2C4U, 0x4FDFF252U, 0xD1BB67F1U, 0xA6BC5767U, 0x3FB506DDU, 0x48B2364BU,
+        0xD80D2BDAU, 0xAF0A1B4CU, 0x36034AF6U, 0x41047A60U, 0xDF60EFC3U, 0xA867DF55U, 0x316E8EEFU, 0x4669BE79U,
+        0xCB61B38CU, 0xBC66831AU, 0x256FD2A0U, 0x5268E236U, 0xCC0C7795U, 0xBB0B4703U, 0x220216B9U, 0x5505262FU,
+        0xC5BA3BBEU, 0xB2BD0B28U, 0x2BB45A92U, 0x5CB36A04U, 0xC2D7FFA7U, 0xB5D0CF31U, 0x2CD99E8BU, 0x5BDEAE1DU,
+        0x9B64C2B0U, 0xEC63F226U, 0x756AA39CU, 0x026D930AU, 0x9C0906A9U, 0xEB0E363FU, 0x72076785U, 0x05005713U,
+        0x95BF4A82U, 0xE2B87A14U, 0x7BB12BAEU, 0x0CB61B38U, 0x92D28E9BU, 0xE5D5BE0DU, 0x7CDCEFB7U, 0x0BDBDF21U,
+        0x86D3D2D4U, 0xF1D4E242U, 0x68DDB3F8U, 0x1FDA836EU, 0x81BE16CDU, 0xF6B9265BU, 0x6FB077E1U, 0x18B74777U,
+        0x88085AE6U, 0xFF0F6A70U, 0x66063BCAU, 0x11010B5CU, 0x8F659EFFU, 0xF862AE69U, 0x616BFFD3U, 0x166CCF45U,
+        0xA00AE278U, 0xD70DD2EEU, 0x4E048354U, 0x3903B3C2U, 0xA7672661U, 0xD06016F7U, 0x4969474DU, 0x3E6E77DBU,
+        0xAED16A4AU, 0xD9D65ADCU, 0x40DF0B66U, 0x37D83BF0U, 0xA9BCAE53U, 0xDEBB9EC5U, 0x47B2CF7FU, 0x30B5FFE9U,
+        0xBDBDF21CU, 0xCABAC28AU, 0x53B39330U, 0x24B4A3A6U, 0xBAD03605U, 0xCDD70693U, 0x54DE5729U, 0x23D967BFU,
+        0xB3667A2EU, 0xC4614AB8U, 0x5D681B02U, 0x2A6F2B94U, 0xB40BBE37U, 0xC30C8EA1U, 0x5A05DF1BU, 0x2D02EF8DU
+    };
+    uint32_t crc = 0xFFFFFFFFU;
+    for (uint8_t b : data) {
+        uint32_t idx = (crc ^ b) & 0xFFU;
+        crc = table[idx] ^ (crc >> 8);
+    }
+    return crc ^ 0xFFFFFFFFU;
+}
+
+struct Sha256 {
+    std::array<uint32_t, 8> h{};
+    std::array<uint8_t, 64> buffer{};
+    uint64_t length = 0;
+    size_t buffer_len = 0;
+
+    Sha256();
+    void update(const uint8_t* data, size_t len);
+    std::array<uint8_t, 32> finish();
+private:
+    void process_block(const uint8_t* block);
+};
+
+
+inline Sha256::Sha256() {
+    h = {0x6a09e667U, 0xbb67ae85U, 0x3c6ef372U, 0xa54ff53aU,
+         0x510e527fU, 0x9b05688cU, 0x1f83d9abU, 0x5be0cd19U};
+}
+
+inline void Sha256::update(const uint8_t* data, size_t len) {
+    static constexpr uint32_t k[64] = {
+        0x428a2f98U,0x71374491U,0xb5c0fbcfU,0xe9b5dba5U,0x3956c25bU,0x59f111f1U,0x923f82a4U,0xab1c5ed5U,
+        0xd807aa98U,0x12835b01U,0x243185beU,0x550c7dc3U,0x72be5d74U,0x80deb1feU,0x9bdc06a7U,0xc19bf174U,
+        0xe49b69c1U,0xefbe4786U,0x0fc19dc6U,0x240ca1ccU,0x2de92c6fU,0x4a7484aaU,0x5cb0a9dcU,0x76f988daU,
+        0x983e5152U,0xa831c66dU,0xb00327c8U,0xbf597fc7U,0xc6e00bf3U,0xd5a79147U,0x06ca6351U,0x14292967U,
+        0x27b70a85U,0x2e1b2138U,0x4d2c6dfcU,0x53380d13U,0x650a7354U,0x766a0abbU,0x81c2c92eU,0x92722c85U,
+        0xa2bfe8a1U,0xa81a664bU,0xc24b8b70U,0xc76c51a3U,0xd192e819U,0xd6990624U,0xf40e3585U,0x106aa070U,
+        0x19a4c116U,0x1e376c08U,0x2748774cU,0x34b0bcb5U,0x391c0cb3U,0x4ed8aa4aU,0x5b9cca4fU,0x682e6ff3U,
+        0x748f82eeU,0x78a5636fU,0x84c87814U,0x8cc70208U,0x90befffaU,0xa4506cebU,0xbef9a3f7U,0xc67178f2U};
+    length += len * 8;
+    size_t i = 0;
+    if (buffer_len && buffer_len + len >= 64) {
+        std::memcpy(buffer.data() + buffer_len, data, 64 - buffer_len);
+        process_block(buffer.data());
+        i += 64 - buffer_len;
+        buffer_len = 0;
+    }
+    for (; i + 64 <= len; i += 64) {
+        process_block(data + i);
+    }
+    if (i < len) {
+        std::memcpy(buffer.data() + buffer_len, data + i, len - i);
+        buffer_len += len - i;
+    }
+}
+
+inline void Sha256::process_block(const uint8_t* block) {
+    uint32_t w[64];
+    for (int i = 0; i < 16; ++i) {
+        w[i] = (static_cast<uint32_t>(block[i*4]) << 24) |
+               (static_cast<uint32_t>(block[i*4+1]) << 16) |
+               (static_cast<uint32_t>(block[i*4+2]) << 8) |
+               (static_cast<uint32_t>(block[i*4+3]));
+    }
+    for (int i = 16; i < 64; ++i) {
+        uint32_t s0 = std::rotr(w[i-15],7) ^ std::rotr(w[i-15],18) ^ (w[i-15] >> 3);
+        uint32_t s1 = std::rotr(w[i-2],17) ^ std::rotr(w[i-2],19) ^ (w[i-2] >> 10);
+        w[i] = w[i-16] + s0 + w[i-7] + s1;
+    }
+    uint32_t a=h[0],b=h[1],c=h[2],d=h[3],e=h[4],f=h[5],g=h[6],h0=h[7];
+    for (int i = 0; i < 64; ++i) {
+        uint32_t S1 = std::rotr(e,6) ^ std::rotr(e,11) ^ std::rotr(e,25);
+        uint32_t ch = (e & f) ^ (~e & g);
+        uint32_t temp1 = h0 + S1 + ch + k[i] + w[i];
+        uint32_t S0 = std::rotr(a,2) ^ std::rotr(a,13) ^ std::rotr(a,22);
+        uint32_t maj = (a & b) ^ (a & c) ^ (b & c);
+        uint32_t temp2 = S0 + maj;
+        h0 = g;
+        g = f;
+        f = e;
+        e = d + temp1;
+        d = c;
+        c = b;
+        b = a;
+        a = temp1 + temp2;
+    }
+    h[0]+=a;h[1]+=b;h[2]+=c;h[3]+=d;h[4]+=e;h[5]+=f;h[6]+=g;h[7]+=h0;
+}
+
+inline std::array<uint8_t,32> Sha256::finish() {
+    buffer[buffer_len++] = 0x80;
+    if (buffer_len > 56) {
+        while (buffer_len < 64) buffer[buffer_len++] = 0;
+        process_block(buffer.data());
+        buffer_len = 0;
+    }
+    while (buffer_len < 56) buffer[buffer_len++] = 0;
+    for (int i=7;i>=0;--i) buffer[buffer_len++] = (length >> (i*8)) & 0xFF;
+    process_block(buffer.data());
+    std::array<uint8_t,32> out{};
+    for (int i=0;i<8;++i) {
+        out[i*4] = (h[i]>>24)&0xFF;
+        out[i*4+1] = (h[i]>>16)&0xFF;
+        out[i*4+2] = (h[i]>>8)&0xFF;
+        out[i*4+3] = h[i]&0xFF;
+    }
+    return out;
+}
+
+} // namespace rzp
+
+#endif // RZP_CRYPTO_UTILS_H

--- a/rzp/src/rzp.cpp
+++ b/rzp/src/rzp.cpp
@@ -1,5 +1,6 @@
 #include "ledgerizer/ledgerizer.h"
 #include "ansx.h"
+#include "crypto_utils.h"
 
 #include <fstream>
 #include <iostream>
@@ -38,14 +39,23 @@ std::vector<uint8_t> encode_container(const std::vector<uint8_t>& raw) {
     std::vector<uint8_t> ansx_bytes(ansx_ptr, ansx_ptr + ansx_len);
     ansx_free(ansx_ptr, ansx_len);
 
+    uint32_t crc = rzp::crc32(ansx_bytes);
+    rzp::Sha256 hasher;
+    hasher.update(raw.data(), raw.size());
+    auto digest = hasher.finish();
+
     uint32_t len = static_cast<uint32_t>(ansx_bytes.size());
     std::vector<uint8_t> out;
-    out.reserve(4 + sizeof(uint32_t) + len);
+    out.reserve(4 + 8 + len + digest.size());
     out.insert(out.end(), MAGIC, MAGIC + 4);
     for (int i = 0; i < 4; ++i) {
         out.push_back(static_cast<uint8_t>((len >> (i * 8)) & 0xFF));
     }
+    for (int i = 0; i < 4; ++i) {
+        out.push_back(static_cast<uint8_t>((crc >> (i * 8)) & 0xFF));
+    }
     out.insert(out.end(), ansx_bytes.begin(), ansx_bytes.end());
+    out.insert(out.end(), digest.begin(), digest.end());
     return out;
 }
 
@@ -57,16 +67,35 @@ std::vector<uint8_t> decode_container(const std::vector<uint8_t>& container) {
     for (int i = 0; i < 4; ++i) {
         len |= static_cast<uint32_t>(container[4 + i]) << (i * 8);
     }
-    if (container.size() < 8 + len) {
+    uint32_t crc = 0;
+    for (int i = 0; i < 4; ++i) {
+        crc |= static_cast<uint32_t>(container[8 + i]) << (i * 8);
+    }
+    size_t offset = 12;
+    if (container.size() < offset + len + 32) {
         throw std::runtime_error("Invalid container: length mismatch");
     }
-    std::vector<uint8_t> ansx_bytes(container.begin() + 8, container.begin() + 8 + len);
+    std::vector<uint8_t> ansx_bytes(container.begin() + offset,
+                                    container.begin() + offset + len);
+    uint32_t crc_calc = rzp::crc32(ansx_bytes);
+    if (crc != crc_calc) {
+        throw std::runtime_error("CRC mismatch");
+    }
     uint32_t ser_len = 0;
     uint8_t* ser_ptr = ansx_decode(ansx_bytes.data(), len, &ser_len);
     std::vector<uint8_t> ser(ser_ptr, ser_ptr + ser_len);
     ansx_free(ser_ptr, ser_len);
     auto ledger = ledgerizer::deserialize(ser);
-    return ledgerizer::decode(ledger);
+    auto raw = ledgerizer::decode(ledger);
+    rzp::Sha256 hasher;
+    hasher.update(raw.data(), raw.size());
+    auto digest = hasher.finish();
+    std::array<uint8_t,32> stored{};
+    std::copy(container.begin() + offset + len, container.begin() + offset + len + 32, stored.begin());
+    if (!std::equal(digest.begin(), digest.end(), stored.begin())) {
+        throw std::runtime_error("SHA-256 mismatch");
+    }
+    return raw;
 }
 
 void print_usage(const char* exe) {

--- a/rzp/tests/CMakeLists.txt
+++ b/rzp/tests/CMakeLists.txt
@@ -2,11 +2,16 @@
 
 add_executable(rzp_cli_test cli_roundtrip.cpp)
 
+add_executable(rzp_integrity_test integrity_check.cpp)
+
 target_compile_definitions(rzp_cli_test PRIVATE RZP_BIN_PATH="$<TARGET_FILE:rzp>")
 
 target_link_libraries(rzp_cli_test PRIVATE ledgerizer)
 
 add_test(NAME rzp_cli_roundtrip COMMAND rzp_cli_test)
+target_compile_definitions(rzp_integrity_test PRIVATE RZP_BIN_PATH="$<TARGET_FILE:rzp>")
+target_link_libraries(rzp_integrity_test PRIVATE ledgerizer)
+add_test(NAME rzp_integrity_check COMMAND rzp_integrity_test)
 
 file(WRITE ${CMAKE_CURRENT_BINARY_DIR}/png_1x1.hex "89504E470D0A1A0A0000000D49484452000000010000000108060000001F15C4890000000A49444154789C63600000020001E221BC330000000049454E44AE426082")
 

--- a/rzp/tests/integrity_check.cpp
+++ b/rzp/tests/integrity_check.cpp
@@ -1,0 +1,48 @@
+#include <cstdlib>
+#include <fstream>
+#include <vector>
+#include <cassert>
+#include <iostream>
+
+#ifndef RZP_BIN_PATH
+#define RZP_BIN_PATH "rzp"
+#endif
+
+static const unsigned char PNG_1x1[] = {
+    0x89,0x50,0x4E,0x47,0x0D,0x0A,0x1A,0x0A,0x00,0x00,0x00,0x0D,0x49,0x48,0x44,0x52,
+    0x00,0x00,0x00,0x01,0x00,0x00,0x00,0x01,0x08,0x06,0x00,0x00,0x00,0x1F,0x15,0xC4,
+    0x89,0x00,0x00,0x00,0x0A,0x49,0x44,0x41,0x54,0x78,0x9C,0x63,0x60,0x00,0x00,0x00,
+    0x02,0x00,0x01,0xE2,0x21,0xBC,0x33,0x00,0x00,0x00,0x00,0x49,0x45,0x4E,0x44,0xAE,
+    0x42,0x60,0x82
+};
+
+int main() {
+    const char* in_png = "test_input.png";
+    const char* out_rbt = "test_output.rbt";
+    const char* out_png = "test_roundtrip.png";
+
+    std::ofstream ofs(in_png, std::ios::binary);
+    ofs.write(reinterpret_cast<const char*>(PNG_1x1), sizeof(PNG_1x1));
+    ofs.close();
+
+    std::string cmd_encode = std::string(RZP_BIN_PATH) + " encode " + in_png + " " + out_rbt;
+    std::string cmd_decode = std::string(RZP_BIN_PATH) + " decode " + out_rbt + " " + out_png;
+
+    assert(std::system(cmd_encode.c_str()) == 0);
+
+    // Corrupt one byte in the container
+    std::fstream cfile(out_rbt, std::ios::in | std::ios::out | std::ios::binary);
+    cfile.seekp(16); // somewhere in the payload
+    char b;
+    cfile.read(&b, 1);
+    cfile.seekp(16);
+    b ^= 0xFF; // flip bits
+    cfile.write(&b, 1);
+    cfile.close();
+
+    int ret = std::system(cmd_decode.c_str());
+    assert(ret != 0 && "Decoder should fail on corrupted file");
+
+    std::cout << "Integrity check test passed\n";
+    return 0;
+}


### PR DESCRIPTION
## Summary
- add CRC32 and SHA256 helpers
- write CRC and SHA256 in `rzp` container
- verify integrity on decode
- add integrity test for corrupted files

## Testing
- `cargo test --workspace --release` *(fails: failed to download from crates.io)*
- `cmake -S . -B build && cmake --build build --target rzp_cli_test` (passes)
- `cmake --build build --target rzp_integrity_test` (passes)
- `ctest --output-on-failure` *(fails: rzp binary missing due to cargo fetch fail)*

------
https://chatgpt.com/codex/tasks/task_e_684cd0f9193083329d52e57729297b21